### PR TITLE
Add local-storage support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
                  [org.clojure/clojurescript "1.10.238"]
                  [reagent "0.7.0"]
                  [lein-doo "0.1.10"]
+                 ;; OpenJDK11 seems to require jakarta.xml.bind-api
+                 ;; and jaxb-runtime as explicit requirements.
                  [jakarta.xml.bind/jakarta.xml.bind-api "2.3.2"]
                  [org.glassfish.jaxb/jaxb-runtime "2.3.2"]
                  [alandipert/storage-atom "1.2.4"]]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,10 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]
                  [reagent "0.7.0"]
-                 [lein-doo "0.1.10"]]
+                 [lein-doo "0.1.10"]
+                 [jakarta.xml.bind/jakarta.xml.bind-api "2.3.2"]
+                 [org.glassfish.jaxb/jaxb-runtime "2.3.2"]
+                 [alandipert/storage-atom "1.2.4"]]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-figwheel "0.5.15"]

--- a/src/simplify_debts/views.cljs
+++ b/src/simplify_debts/views.cljs
@@ -5,11 +5,15 @@
             [goog.string.format]
             [alandipert.storage-atom :as storage-atom]))
 
+(def ^:constant initial-participants [])
+
 (defonce participants
-  (storage-atom/local-storage (r/atom []) :participants))
+  (storage-atom/local-storage (r/atom initial-participants) :participants))
+
+(def ^:constant initial-rows [{:id 0}])
 
 (defonce rows
-  (storage-atom/local-storage (r/atom [{:id 0}]) :rows))
+  (storage-atom/local-storage (r/atom initial-rows) :rows))
 
 (defonce clear-text-inputs
   (r/atom 0))
@@ -107,8 +111,8 @@
      [:li (str from " pays " to ": " (format-sum amount))])])
 
 (defn- reset-local-storage []
-  (reset! participants [])
-  (reset! rows [{:id 0}])
+  (reset! participants initial-participants)
+  (reset! rows initial-rows)
   (swap! clear-text-inputs inc))
 
 (defn home-page []


### PR DESCRIPTION
Use `alandipert/storage-atom` for local storage support. Persist
participants and rows in browser's local storage. Add reset button for clearing
up the screen.

Adds also `jakarta.xml.bind-api` and `jaxb-runtime` as otherwise the
project wouldn't start with OpenJDK 11.